### PR TITLE
Caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "3.1.3"
 
 gem "rails", "~> 7.0.4"
 
+gem "dalli", "~> 3.2.3"
 gem "dry-initializer", "~> 3.1.1"
 gem "dry-struct", "~> 1.6.0"
 gem "faraday", "~> 2.7.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    dalli (3.2.3)
     date (3.3.3)
     diff-lcs (1.5.0)
     dry-core (1.0.0)
@@ -207,6 +208,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  dalli (~> 3.2.3)
   dry-initializer (~> 3.1.1)
   dry-struct (~> 1.6.0)
   faraday (~> 2.7.2)

--- a/app/controllers/forecast_controller.rb
+++ b/app/controllers/forecast_controller.rb
@@ -8,7 +8,9 @@ class ForecastController < ApplicationController
   private
 
   def forecast
-    @_forecast ||= Forecast.fetch(location: location)
+    @_forecast ||= Rails.cache.fetch(location.coordinates, expires_in: 30.minutes) do
+      Forecast.fetch(location: location)
+    end
   end
 
   def location

--- a/app/models/current_weather.rb
+++ b/app/models/current_weather.rb
@@ -1,0 +1,15 @@
+require 'dry-struct'
+
+class CurrentWeather < Dry::Struct
+  attribute :weathercode, Types::Integer
+  attribute :temperature, Types::Float
+  attribute :timestamp, Types::Integer.default { DateTime.now.to_i }
+
+  def to_hash
+    {
+      weathercode: weathercode,
+      temperature: temperature,
+      timestamp: timestamp.to_i
+    }
+  end
+end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,0 +1,16 @@
+class Location < Dry::Struct
+  attribute :latitude, Types::Float
+  attribute :longitude, Types::Float
+
+  def valid?
+    true
+  end
+
+  def invalid?
+    false
+  end
+
+  def coordinates
+    [latitude, longitude]
+  end
+end

--- a/app/models/null_location.rb
+++ b/app/models/null_location.rb
@@ -1,0 +1,13 @@
+class NullLocation
+  def coordinates
+    []
+  end
+
+  def valid?
+    false
+  end
+
+  def invalid?
+    true
+  end
+end

--- a/app/services/find_location.rb
+++ b/app/services/find_location.rb
@@ -33,35 +33,3 @@ end
 module Types
   include Dry.Types()
 end
-
-
-class Location < Dry::Struct::Value
-  attribute :latitude, Types::Float
-  attribute :longitude, Types::Float
-
-  def valid?
-    true
-  end
-
-  def invalid?
-    false
-  end
-
-  def coordinates
-    [latitude, longitude]
-  end
-end
-
-class NullLocation
-  def coordinates
-    []
-  end
-
-  def valid?
-    false
-  end
-
-  def invalid?
-    true
-  end
-end

--- a/app/services/find_location.rb
+++ b/app/services/find_location.rb
@@ -29,7 +29,3 @@ class FindLocation
     @query || "Cupertino"
   end
 end
-
-module Types
-  include Dry.Types()
-end

--- a/app/services/forecast.rb
+++ b/app/services/forecast.rb
@@ -50,17 +50,4 @@ class Forecast
 
     CurrentWeather.new(parsed_body[:current_weather]).to_hash
   end
-
-  class CurrentWeather < Dry::Struct::Value
-    attribute :weathercode, Types::Integer
-    attribute :temperature, Types::Float
-
-    def to_hash
-      {
-        weathercode: weathercode,
-        temperature: temperature,
-        time: Time.now
-      }
-    end
-  end
 end

--- a/app/services/forecast.rb
+++ b/app/services/forecast.rb
@@ -58,7 +58,8 @@ class Forecast
     def to_hash
       {
         weathercode: weathercode,
-        temperature: temperature
+        temperature: temperature,
+        time: Time.now
       }
     end
   end

--- a/app/services/forecast.rb
+++ b/app/services/forecast.rb
@@ -24,7 +24,7 @@ class Forecast
   end
 
   def to_json
-    fetch.to_json
+    to_hash.to_json
   end
 
   private

--- a/app/services/forecast.rb
+++ b/app/services/forecast.rb
@@ -2,11 +2,6 @@ require "dry-initializer"
 require "dry-struct"
 require "faraday"
 
-# TODO: Move me
-module Types
-  include Dry.Types()
-end
-
 class Forecast
   extend Dry::Initializer
   extend Forwardable

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,7 +41,16 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :mem_cache_store,
+                        (ENV["MEMCACHIER_SERVERS"] || "").split(","),
+                        {
+                          username: ENV["MEMCACHIER_USERNAME"],
+                          password: ENV["MEMCACHIER_PASSWORD"],
+                          failover: true,
+                          socket_timeout: 1.5,
+                          socket_failure_delay: 0.2,
+                          down_retry_delay: 60
+                        }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/dry-types.rb
+++ b/config/initializers/dry-types.rb
@@ -1,0 +1,5 @@
+require "dry-types"
+
+module Types
+  include Dry.Types()
+end

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -2,4 +2,7 @@ require "geocoder"
 
 # The global Geocoder object is injected, but configured here. For the purposes
 # of this app, the geocoder selected is the free, fair-use Photon API.
-Geocoder.configure(lookup: :photon)
+Geocoder.configure(
+  lookup: :photon,
+  cache: Geocoder::CacheStore::Generic.new(Rails.cache, {})
+)

--- a/spec/requests/forecast_spec.rb
+++ b/spec/requests/forecast_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "A /forecast endpoint", vcr: { record: :new_episodes } do
       # FIXME: Danger! Not DRY and not permissive
       parsed_response = JSON.parse(response.body, symbolize_names: true)
 
-      expect(parsed_response.keys).to contain_exactly(*%i(temperature weathercode time))
+      expect(parsed_response.keys).to contain_exactly(*%i(temperature weathercode timestamp))
     end
 
     it "responds with the forecast for Cupertino" do

--- a/spec/requests/forecast_spec.rb
+++ b/spec/requests/forecast_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "A /forecast endpoint", vcr: { record: :new_episodes } do
       # FIXME: Danger! Not DRY and not permissive
       parsed_response = JSON.parse(response.body, symbolize_names: true)
 
-      expect(parsed_response.keys).to contain_exactly(*%i(temperature weathercode))
+      expect(parsed_response.keys).to contain_exactly(*%i(temperature weathercode time))
     end
 
     it "responds with the forecast for Cupertino" do


### PR DESCRIPTION
This PR proposes two layers of caching:

1. Geocoding lookups are cached by Geocoder in `Rails.cache`, which in the production environment is configured to be a memcached instance.
2. Weather forecast lookups are also stored in Rails.cache, with a 30-minute expiry, and using the geocoded coordinates as the discriminator.

The response payload has also been expanded to include a timestamp indicating when the forecast was retrieved. Finally, a variety of refactorings have been done to make the codebase more pleasant.

Merging this PR will close #4.